### PR TITLE
Unify the matchAll options

### DIFF
--- a/Classes/TypesetKit.h
+++ b/Classes/TypesetKit.h
@@ -16,6 +16,7 @@ typedef TypesetKit *(^TypesettingRangeBlock)(NSRange);
 typedef TypesetKit *(^TypesettingStringBlock)(NSString *);
 typedef TypesetKit *(^TypesettingColorBlock)(UIColor *);
 typedef TypesetKit *(^TypesettingFontBlock)(NSString *, CGFloat);
+typedef TypesetKit *(^TypesettingMatchBlock)(NSString *,NSStringCompareOptions);
 
 @property (nonatomic, strong) NSMutableAttributedString *string;
 
@@ -25,7 +26,9 @@ typedef TypesetKit *(^TypesettingFontBlock)(NSString *, CGFloat);
 - (TypesettingIntegerBlock)length;
 - (TypesettingRangeBlock)range;
 - (TypesettingStringBlock)match;
+- (TypesettingMatchBlock)matchWithOptions;
 - (TypesettingStringBlock)matchAll;
+- (TypesettingMatchBlock)matchAllWithOptions;
 - (TypesetKit *)all;
 
 - (TypesettingColorBlock)color;

--- a/Classes/TypesetKit.m
+++ b/Classes/TypesetKit.m
@@ -95,7 +95,7 @@
         while (range.length != 0) {
             NSInteger location = range.location + range.length;
             NSInteger length = self.string.length - location;
-            range = [self.string.string rangeOfString:substring options:NSCaseInsensitiveSearch range:NSMakeRange(location, length)];
+            range = [self.string.string rangeOfString:substring options:0 range:NSMakeRange(location, length)];
             [self.attributeRanges addObject:[NSValue valueWithRange:range]];
         }
         return self;

--- a/Classes/TypesetKit.m
+++ b/Classes/TypesetKit.m
@@ -111,6 +111,30 @@
     };
 }
 
+- (TypesettingMatchBlock)matchAllWithOptions {
+    return ^(NSString *substring,NSStringCompareOptions options) {
+        NSRange range = [self.string.string rangeOfString:substring options:options];
+        [self.attributeRanges removeAllObjects];
+        [self.attributeRanges addObject:[NSValue valueWithRange:range]];
+        while (range.length != 0) {
+            NSInteger location = range.location + range.length;
+            NSInteger length = self.string.length - location;
+            range = [self.string.string rangeOfString:substring options:options range:NSMakeRange(location, length)];
+            [self.attributeRanges addObject:[NSValue valueWithRange:range]];
+        }
+        return self;
+    };
+}
+
+- (TypesettingMatchBlock)matchWithOptions {
+    return ^(NSString *substring,NSStringCompareOptions options) {
+        NSRange range = [self.string.string rangeOfString:substring options:options];
+        [self.attributeRanges removeAllObjects];
+        [self.attributeRanges addObject:[NSValue valueWithRange:range]];
+        return self;
+    };
+}
+
 - (TypesetKit *)all {
     [self.attributeRanges removeAllObjects];
     [self.attributeRanges addObject:[NSValue valueWithLocation:0 length:self.string.length]];

--- a/Typeset/ViewController.m
+++ b/Typeset/ViewController.m
@@ -20,7 +20,7 @@
     UILabel *label = [[UILabel alloc] initWithFrame:self.view.frame];
     [self.view addSubview:label];
     label.textAlignment = NSTextAlignmentCenter;
-    NSMutableAttributedString *mas = @"Hello typeset".typeset.match(@"Hello").fontSize(40)
+    NSMutableAttributedString *mas = @"Hello typeset, hello".typeset.matchAll(@"Hello").fontSize(40)
         .match(@"type").purple
         .match(@"set").blue
         .string;


### PR DESCRIPTION
The first result of matchAll is case sensitive, but the rest are case insensitive. This pull request fixed this.
And added two methods to specify compareOptions.
