### PR TITLE
在 NSString 上调用 typeset 时清空原先生成的 attributedString

### DIFF
--- a/Classes/NSString+Typeset.m
+++ b/Classes/NSString+Typeset.m
@@ -17,9 +17,9 @@
     TypesetKit *typeset = objc_getAssociatedObject(self, @selector(typeset));
     if (!typeset) {
         typeset = [[TypesetKit alloc] init];
-        typeset.string = [[NSMutableAttributedString alloc] initWithString:self];
         objc_setAssociatedObject(self, @selector(typeset), typeset, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
+    typeset.string = [[NSMutableAttributedString alloc] initWithString:self];
     return typeset;
 }
 

--- a/TypesetTests/TypesetTests.m
+++ b/TypesetTests/TypesetTests.m
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
-
+#import "Typeset.h"
 @interface TypesetTests : XCTestCase
 
 @end
@@ -28,6 +28,50 @@
 - (void)testExample {
     // This is an example of a functional test case.
     XCTAssert(YES, @"Pass");
+}
+
+
+- (void)testSelfEqual {
+    
+    NSString *txt = @"Hello typeset";
+    
+    NSMutableAttributedString *attributedTxt1 = txt.typeset.matchAll(@"o").red.string;
+    
+    NSMutableAttributedString *attributedTxt2 = txt.typeset.matchAll(@"l").red.string;
+    
+    XCTAssertFalse([attributedTxt1 isEqualToAttributedString:attributedTxt2]);
+    
+    NSMutableAttributedString *attributedTxt3 = txt.typeset.matchAll(@"o").red.string;
+    
+    XCTAssertTrue([attributedTxt1 isEqualToAttributedString:attributedTxt3]);
+    
+}
+
+- (void)testEqual {
+    
+    NSDictionary *obj1 = @{@"abc":@"Hello typeset Hello typeset Hello typeset Hello typeset Hello typeset Hello typeset Hello typeset Hello typeset Hello typeset "};
+    
+    NSDictionary *tmpObj = @{@"def":@"Hello typeset Hello typeset Hello typeset Hello typeset Hello typeset Hello typeset Hello typeset Hello typeset Hello typeset "};
+    NSDictionary *obj2 = [[NSDictionary alloc] initWithDictionary:tmpObj];
+    
+    NSString *txt = obj1[@"abc"];
+    NSString *txt2 = [obj2[@"def"] copy]; // no difference, just to demonstrate the optimization of NSString done by Apple
+    
+//    XCTAssertFalse([txt isEqual:txt2]);
+    
+    //attributedString from txt1
+    NSMutableAttributedString *attributedTxt1 = txt.typeset.matchAll(@"o").red.string;
+    
+    //attributedString from txt2
+    NSMutableAttributedString *attributedTxt2_1 = txt2.typeset.matchAll(@"o").red.string;
+    XCTAssertTrue([attributedTxt1 isEqualToAttributedString:attributedTxt2_1]);
+    
+    NSMutableAttributedString *attributedTxt2_2 = txt2.typeset.matchAll(@"l").red.string;
+    XCTAssertFalse([attributedTxt1 isEqualToAttributedString:attributedTxt2_2]);
+    
+    NSMutableAttributedString *attributedTxt2_3 = txt2.typeset.matchAll(@"o").red.string;
+    XCTAssertTrue([attributedTxt1 isEqualToAttributedString:attributedTxt2_3]);
+    
 }
 
 - (void)testPerformanceExample {


### PR DESCRIPTION
由于苹果对 NSString 的优化，相同内容的 NSString 都是同一个对象，其内存地址也都是一样的，即使是 copy 的。
这会导致如果多次对同样内容的 string 调用 typeset，上次加的样式会残留着。

这个 PR 通过每次调用 typeset 时清空原先生成的 attributedString 来修正这个问题，同时也加了两个测试。
