### PR TITLE
fix error unrecognized selector[removeObserver:] sent to instance

### DIFF
--- a/Classes/UITextView+Typeset.m
+++ b/Classes/UITextView+Typeset.m
@@ -91,6 +91,11 @@
     __block void (*originalDealloc)(__unsafe_unretained id, SEL) = NULL;
 
     id newDealloc = ^(__unsafe_unretained id objSelf) {
+        
+        if (![objSelf respondsToSelector:@selector(removeObserver:)]) {
+            return;
+        }
+        
         [objSelf removeObserver:self];
 
         if (originalDealloc == NULL) {


### PR DESCRIPTION
Fix an error 'unrecognized selector[removeObserver:] sent to instance' that is not kind of object allowing removeObserver.