### PR TITLE
Add option to set an exact UIFont

### DIFF
--- a/Classes/NSMutableAttributedString+Typeset.h
+++ b/Classes/NSMutableAttributedString+Typeset.h
@@ -23,6 +23,6 @@
 - (NSMutableAttributedString *(^)(NSUInteger))fontSize;
 - (NSMutableAttributedString *(^)(NSString *))fontName;
 - (NSMutableAttributedString *(^)(NSString *, CGFloat))font;
-
+- (NSMutableAttributedString *(^)(UIFont *))exactFont;
 
 @end

--- a/Classes/NSMutableAttributedString+Typeset.m
+++ b/Classes/NSMutableAttributedString+Typeset.m
@@ -76,4 +76,10 @@
     };
 }
 
+- (NSMutableAttributedString *(^)(UIFont *))exactFont {
+    return ^(UIFont *font) {
+        return self.typeset.exactFont(font).string;
+    };
+}
+
 @end

--- a/Classes/NSString+Typeset.h
+++ b/Classes/NSString+Typeset.h
@@ -37,5 +37,6 @@
 - (NSMutableAttributedString *(^)(NSUInteger))fontSize;
 - (NSMutableAttributedString *(^)(NSString *))fontName;
 - (NSMutableAttributedString *(^)(NSString *, CGFloat))font;
+- (NSMutableAttributedString *(^)(UIFont *))exactFont;
 
 @end

--- a/Classes/NSString+Typeset.m
+++ b/Classes/NSString+Typeset.m
@@ -117,4 +117,10 @@
     };
 }
 
+- (NSMutableAttributedString *(^)(UIFont *))exactFont {
+    return ^(UIFont *font) {
+        return self.typeset.exactFont(font).string;
+    };
+}
+
 @end

--- a/Classes/TypesetKit.h
+++ b/Classes/TypesetKit.h
@@ -21,6 +21,7 @@
 #define TypesetObjectBlock TypesetBlock(id)
 #define TypesetColorBlock TypesetBlock(UIColor *)
 #define TypesetFontBlock TypesetBlock(NSString *, CGFloat)
+#define TypesetExactFontBlock TypesetBlock(UIFont *font)
 #define TypesetMatchBlock TypesetBlock(NSString *, NSStringCompareOptions)
 
 #define TSAttributedString(...) _TSAttributedString(metamacro_argcount(__VA_ARGS__), __VA_ARGS__)
@@ -37,6 +38,7 @@ NSMutableAttributedString *_TSAttributedString(int size, ...);
 - (TypesetStringBlock)fontName;
 - (TypesetCGFloatBlock)fontSize;
 - (TypesetFontBlock)font;
+- (TypesetExactFontBlock)exactFont;
 - (TypesetKit *)regular;
 - (TypesetKit *)light;
 - (TypesetKit *)bold;

--- a/Classes/TypesetKit.m
+++ b/Classes/TypesetKit.m
@@ -112,6 +112,16 @@ NSMutableAttributedString *_TSAttributedString(int size, ...) {
     };
 }
 
+- (TypesetExactFontBlock)exactFont {
+    return ^(UIFont *font) {
+        for (NSValue *value in self.attributeRanges) {
+            NSRange range = [value rangeValue];
+            [self.string addAttribute:NSFontAttributeName value:font range:range];
+        }
+        return self;
+    };
+}
+
 - (TypesetStringBlock)fontName {
     return ^(NSString *fontName) {
         if (self.string.length) {


### PR DESCRIPTION
I find it out a no-brainer to be able to directly set a `UIFont` instead of a name and size. In most cases I already have a `UIFont` instance, and currently I have to use:

```obj-c
UIFont *myFont = ...;
@"Test text".typeset.font(myFont.fontName, myFont.pointSize);
```

instead of:

```obj-c
UIFont *myFont = ...;
@"Test text".typeset.exactFont(myFont);
```

The only thing I'm not very fond of is the `exactFont` name. :/