### PR TITLE
Fix:The same strings sharing the same typeset object and NSMutablePar…

### DIFF
--- a/Classes/NSMutableAttributedString+Typeset.m
+++ b/Classes/NSMutableAttributedString+Typeset.m
@@ -16,9 +16,12 @@
     TypesetKit *typeset = objc_getAssociatedObject(self, @selector(typeset));
     if (!typeset) {
         typeset = [[TypesetKit alloc] init];
-        typeset.string = [[NSMutableAttributedString alloc] initWithAttributedString:self];
         objc_setAssociatedObject(self, @selector(typeset), typeset, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }else {
+        [typeset restoreParagraphStyle];
+        typeset.string = nil;
     }
+    typeset.string = [[NSMutableAttributedString alloc] initWithAttributedString:self];
     return typeset;
 }
 

--- a/Classes/NSString+Typeset.m
+++ b/Classes/NSString+Typeset.m
@@ -18,6 +18,9 @@
     if (!typeset) {
         typeset = [[TypesetKit alloc] init];
         objc_setAssociatedObject(self, @selector(typeset), typeset, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }else {
+        [typeset restoreParagraphStyle];
+        typeset.string = nil;
     }
     typeset.string = [[NSMutableAttributedString alloc] initWithString:self];
     return typeset;

--- a/Classes/TypesetKit.h
+++ b/Classes/TypesetKit.h
@@ -90,4 +90,6 @@ NSMutableAttributedString *_TSAttributedString(int size, ...);
 - (TypesetBlock(NSWritingDirection))baseWritingDirection;
 - (TypesetBlock(BOOL))allowsDefaultTighteningForTruncation;
 
+- (void)restoreParagraphStyle;
+
 @end

--- a/Classes/TypesetKit.m
+++ b/Classes/TypesetKit.m
@@ -419,4 +419,9 @@ NSMutableAttributedString *_TSAttributedString(int size, ...) {
     return mas;
 }
 
+- (void)restoreParagraphStyle {
+    
+    _paragraphStyle = nil;
+}
+
 @end


### PR DESCRIPTION
The same strings sharing the same typeset object and NSMutableParagraphStyle object which will sometimes disturbing text style for each other
So, add a retore paragraphstyle method when calling .typeset to ensure paragraphstyle is clean